### PR TITLE
Remove delayed_task gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem "figaro"
 gem "faraday"
 gem "rails_12factor", group: :production
-gem "delayed_task", group: :production
 
 group :development, :test do
   gem "rspec-rails", "~> 3.0"

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,3 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
-
-require "tasks/delayed_tasks"


### PR DESCRIPTION
We did not end up needing this gem to seed the data in Heroku