### PR TITLE
Fix legend and change color ratios

### DIFF
--- a/app/assets/javascripts/maps/load_state_map.js
+++ b/app/assets/javascripts/maps/load_state_map.js
@@ -1,4 +1,37 @@
 function loadStateMap(geojson, data) {
+  var
+    stateInfo = {
+      maxCountyInstalls: data.max_county_installs,
+      defaultColor: '#ccebc5',
+      defaultStyle: {
+        weight: 2,
+        opacity: 1,
+        color: 'white',
+        dashArray: '3',
+        fillOpacity: 0.7
+      },
+      dataSetHi: [
+        { level: data.max_county_installs * 0.5,  color: '#08589e' },
+        { level: data.max_county_installs * 0.3,  color: '#2b8cbe' },
+        { level: data.max_county_installs * 0.1,  color: '#4eb3d3' },
+        { level: data.max_county_installs * 0.05, color: '#7bccc4' },
+        { level: data.max_county_installs * 0.02, color: '#a8ddb5' }
+      ],
+      dataSetMed: [
+        { level: data.max_county_installs * 0.6,  color: '#08589e' },
+        { level: data.max_county_installs * 0.5,  color: '#2b8cbe' },
+        { level: data.max_county_installs * 0.4,  color: '#4eb3d3' },
+        { level: data.max_county_installs * 0.3,  color: '#7bccc4' },
+        { level: data.max_county_installs * 0.2,  color: '#a8ddb5' }
+      ],
+      dataSetLow: [
+        { level: 5, color: '#08589e' },
+        { level: 4, color: '#2b8cbe' },
+        { level: 3, color: '#4eb3d3' },
+        { level: 2, color: '#7bccc4' },
+        { level: 1, color: '#a8ddb5' }
+      ]
+    };
   var max_county_installs = data.max_county_installs;
   mymap = L.map('map').setView(data.lat_long, data.zoom);
   var lastClickedLayer = null;
@@ -8,24 +41,18 @@ function loadStateMap(geojson, data) {
       accessToken: 'pk.eyJ1IjoianVsc2ZlbGljIiwiYSI6ImNpbmFmaHlnazBobjZ2MGt2aWltcHN5ZWIifQ.dXiLrMR-naZgZVExDlTlcA'
   }).addTo(mymap);
 
-  function getColor(d) {
-    return d > (max_county_installs * .8) ? '#08589e' :
-           d > (max_county_installs * .6) ? '#2b8cbe' :
-           d > (max_county_installs * .4) ? '#4eb3d3' :
-           d > (max_county_installs * .2) ? '#7bccc4' :
-           d > (max_county_installs * .1) ? '#a8ddb5' :
-                                            '#ccebc5'
+  function getColor(d, dataset) {
+    for (var i=0; i<dataset.length; i++) {
+      if (d > dataset[i].level) { return dataset[i].color; }
+    }
+    return stateInfo.defaultColor;
   }
 
-  function style(feature) {
-    return {
-      fillColor: getColor(feature.properties.installs),
-      weight: 2,
-      opacity: 1,
-      color: 'white',
-      dashArray: '3',
-      fillOpacity: 0.7
-    };
+  function getStyle(feature) {
+    var dataset = stateInfo.maxCountyInstalls < 30 ? stateInfo.dataSetMed : stateInfo.dataSetHi;
+    return _.extend(stateInfo.defaultStyle, {
+      fillColor: getColor(feature.properties.installs, dataset)
+    });
   }
 
   var geojson;
@@ -84,15 +111,27 @@ function loadStateMap(geojson, data) {
 
   var legend = L.control({position: 'bottomright'});
 
+  function createLegend() {
+    var
+      dataset = stateInfo.maxCountyInstalls < 30 ? stateInfo.dataSetMed : stateInfo.dataSetHi,
+      legendSet = _.map(_.reverse(dataset), function (setObject) {
+        return parseInt(setObject.level);
+      });
+    legendSet.unshift(0);
+    return legendSet;
+  };
+
+  var getLegendColor = ['#ccebc5', '#a8ddb5', '#7bccc4', '#4eb3d3', '#2b8cbe', '#08589e']
+
   legend.onAdd = function(map) {
     var div = L.DomUtil.create('div', 'info legend'),
-        grades = [0, parseInt(max_county_installs * .1), parseInt(max_county_installs * .2), parseInt(max_county_installs * .4), parseInt(max_county_installs * .6), parseInt(max_county_installs * .8)],
-        labels = [];
+      grades = createLegend();
+      labels = [];
 
     // loop through our density intervals and generate a label with a colored square for each interval
     for (var i = 0; i < grades.length; i++) {
         div.innerHTML +=
-            '<i style="background:' + getColor(grades[i] + 1) + '"></i> ' +
+            '<i style="background:' + getLegendColor[i] + '"></i> ' +
             grades[i] + (grades[i + 1] ? '&ndash;' + grades[i + 1] + '<br>' : '+');
     }
 
@@ -100,7 +139,7 @@ function loadStateMap(geojson, data) {
   }
 
   var geojson = L.geoJson(geojson, {
-    style: style,
+    style: getStyle,
     onEachFeature: onEachFeature
   }).addTo(mymap);
 

--- a/app/assets/javascripts/maps/load_state_map.js
+++ b/app/assets/javascripts/maps/load_state_map.js
@@ -14,25 +14,17 @@ function loadStateMap(geojson, data) {
         { level: data.max_county_installs * 0.5,  color: '#08589e' },
         { level: data.max_county_installs * 0.3,  color: '#2b8cbe' },
         { level: data.max_county_installs * 0.1,  color: '#4eb3d3' },
-        { level: data.max_county_installs * 0.05, color: '#7bccc4' },
-        { level: data.max_county_installs * 0.02, color: '#a8ddb5' }
-      ],
-      dataSetMed: [
-        { level: data.max_county_installs * 0.6,  color: '#08589e' },
-        { level: data.max_county_installs * 0.5,  color: '#2b8cbe' },
-        { level: data.max_county_installs * 0.4,  color: '#4eb3d3' },
-        { level: data.max_county_installs * 0.3,  color: '#7bccc4' },
-        { level: data.max_county_installs * 0.2,  color: '#a8ddb5' }
+        { level: data.max_county_installs * 0.06, color: '#7bccc4' },
+        { level: data.max_county_installs * 0.03, color: '#a8ddb5' }
       ],
       dataSetLow: [
-        { level: 5, color: '#08589e' },
-        { level: 4, color: '#2b8cbe' },
-        { level: 3, color: '#4eb3d3' },
-        { level: 2, color: '#7bccc4' },
-        { level: 1, color: '#a8ddb5' }
+        { level: 10, color: '#08589e' },
+        { level: 8,  color: '#2b8cbe' },
+        { level: 6,  color: '#4eb3d3' },
+        { level: 4,  color: '#7bccc4' },
+        { level: 2,  color: '#a8ddb5' }
       ]
     };
-  var max_county_installs = data.max_county_installs;
   mymap = L.map('map').setView(data.lat_long, data.zoom);
   var lastClickedLayer = null;
 
@@ -43,13 +35,13 @@ function loadStateMap(geojson, data) {
 
   function getColor(d, dataset) {
     for (var i=0; i<dataset.length; i++) {
-      if (d > dataset[i].level) { return dataset[i].color; }
+      if (d >= dataset[i].level) { return dataset[i].color; }
     }
     return stateInfo.defaultColor;
   }
 
   function getStyle(feature) {
-    var dataset = stateInfo.maxCountyInstalls < 30 ? stateInfo.dataSetMed : stateInfo.dataSetHi;
+    var dataset = stateInfo.maxCountyInstalls < 30 ? stateInfo.dataSetLow : stateInfo.dataSetHi;
     return _.extend(stateInfo.defaultStyle, {
       fillColor: getColor(feature.properties.installs, dataset)
     });
@@ -113,8 +105,8 @@ function loadStateMap(geojson, data) {
 
   function createLegend() {
     var
-      dataset = stateInfo.maxCountyInstalls < 30 ? stateInfo.dataSetMed : stateInfo.dataSetHi,
-      legendSet = _.map(_.reverse(dataset), function (setObject) {
+      dataset = stateInfo.maxCountyInstalls < 30 ? stateInfo.dataSetLow : stateInfo.dataSetHi,
+      legendSet = _.map(_.reverse(_.clone(dataset)), function (setObject) {
         return parseInt(setObject.level);
       });
     legendSet.unshift(0);

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -1,4 +1,3 @@
 class Summary < ActiveRecord::Base
   belongs_to :state
-  
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   <%= render partial: "layouts/nav" %>
   <%= yield %>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.11.2/lodash.min.js"></script>
   <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
   <script src='https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.0.0/Chart.js'></script>
   <%= javascript_include_tag 'application' %>


### PR DESCRIPTION
Created different color settings between states with higher number of installs and lower number of installs to fix the legend for states with a low number of installs. The color settings were also adjusted for the states with a higher number of installs to display more contrast in the colors instead of having so many counties with the lightest color.